### PR TITLE
회원가입 CSS 적용 오류 수정

### DIFF
--- a/frontend/src/pages/SignUp.js
+++ b/frontend/src/pages/SignUp.js
@@ -173,7 +173,7 @@ const SignUp = () => {
             이름
           </label>
           <input
-            className="border-2 border-gray-400 rounded-md h-9 pl-3 focus:border-project focus:text-inputfocus focus:font-semibold"
+            className="border-2 border-gray-400 rounded-md h-9 pl-3 focus:border-project focus:text-inputfocus focus:font-semibold outline-none"
             type="text"
             id="name"
             value={name}
@@ -187,7 +187,7 @@ const SignUp = () => {
             이메일
           </label>
           <input
-            className="border-2 border-gray-400 rounded-md h-9 pl-3 focus:border-project focus:text-inputfocus focus:font-semibold"
+            className="border-2 border-gray-400 rounded-md h-9 pl-3 focus:border-project focus:text-inputfocus focus:font-semibold outline-none"
             type="text"
             id="email"
             value={email}
@@ -201,7 +201,7 @@ const SignUp = () => {
             생년월일
           </label>
           <input
-            className="border-2 border-gray-400 rounded-md h-9 pl-3 focus:border-project focus:text-inputfocus focus:font-semibold"
+            className="border-2 border-gray-400 rounded-md h-9 pl-3 focus:border-project focus:text-inputfocus focus:font-semibold outline-none"
             type="date"
             id="birth"
             value={birth}
@@ -215,7 +215,7 @@ const SignUp = () => {
             닉네임
           </label>
           <input
-            className="border-2 border-gray-400 rounded-md h-9 pl-3 focus:border-project focus:text-inputfocus focus:font-semibold"
+            className="border-2 border-gray-400 rounded-md h-9 pl-3 focus:border-project focus:text-inputfocus focus:font-semibold outline-none"
             type="text"
             id="nickname"
             value={nickname}
@@ -229,7 +229,7 @@ const SignUp = () => {
             비밀번호
           </label>
           <input
-            className="border-2 border-gray-400 rounded-md h-9 pl-3 focus:border-project focus:text-inputfocus focus:font-semibold"
+            className="border-2 border-gray-400 rounded-md h-9 pl-3 focus:border-project focus:text-inputfocus focus:font-semibold outline-none"
             type="password"
             id="password"
             value={password}
@@ -243,7 +243,7 @@ const SignUp = () => {
             비밀번호 확인
           </label>
           <input
-            className="border-2 border-gray-400 rounded-md h-9 pl-3 focus:border-project focus:text-inputfocus focus:font-semibold"
+            className="border-2 border-gray-400 rounded-md h-9 pl-3 focus:border-project focus:text-inputfocus focus:font-semibold outline-none"
             type="password"
             id="passwordConfirm"
             value={passwordConfirm}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4773,6 +4773,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@^2.3.2, fsevents@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"


### PR DESCRIPTION
윈도우에서 접속시에는 input의 border이 검은색으로 나오는 이슈.
![image](https://github.com/SYU-SWST/eat_together/assets/70376320/12c6f311-6988-4408-af46-2d17010cb4fc)

하지만 Mac OS에서 돌려보니 이와 같이 파란색 테두리만 없어져서
![image](https://github.com/SYU-SWST/eat_together/assets/70376320/90f65b39-0637-488f-b0f4-3d053c7a7308)

css에 outline: none; 속성을 부여하였음.